### PR TITLE
Set working chef version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ You must installed on your host machine:
 
 1. [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
 2. [Vagrant](https://www.vagrantup.com/downloads.html)
-3. [Berkshelf](http://berkshelf.com/)
+3. [ChefDK](https://downloads.chef.io/chef-dk/)
 4. [vagrant-berfkshelf plugin](https://github.com/berkshelf/vagrant-berkshelf)
 
 ## Using SonarQube

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -82,7 +82,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # config.berkshelf.except = []
 
   config.vm.provision :chef_solo do |chef|
-    chef.version = '12.10.40'
+    chef.channel = 'stable'
+    chef.version = '12.10.24'
     chef.json = {
       mysql: {
         server_root_password: 'rootpass',


### PR DESCRIPTION
chef 12.10.40 is not available anymore.
any new version is failing at provision - see chef/chef#4948

Also Berkchef is now part of ChefDK, so readme updated accordingly